### PR TITLE
Implement HKDF-SHA256 for Umbral's KDF

### DIFF
--- a/npre/umbral.py
+++ b/npre/umbral.py
@@ -48,7 +48,7 @@ class PRE(object):
             else:
                 self.g = ec.deserialize(self.ecgroup, g)
 
-        self.bitsize = ec.bitsize(self.ecgroup)
+        self.bytesize = ec.bitsize(self.ecgroup)
 
     def kdf(self, ecdata):
         # XXX length
@@ -57,7 +57,7 @@ class PRE(object):
         # TODO: Handle salt somehow
         return HKDF(
             algorithm=hashes.SHA256(),
-            length=32,
+            length=self.bytesize,
             salt=None,
             info=None,
             backend=default_backend()

--- a/npre/umbral.py
+++ b/npre/umbral.py
@@ -9,6 +9,9 @@ from sha3 import keccak_256 as keccak
 from collections import namedtuple
 from functools import reduce
 from operator import mul
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+from cryptography.hazmat.backends import default_backend
 
 
 EncryptedKey = namedtuple('EncryptedKey', ['ekey', 're_id'])
@@ -49,8 +52,16 @@ class PRE(object):
 
     def kdf(self, ecdata):
         # XXX length
-        for_hash = ec.serialize(ecdata)[1:]  # Remove the first (type) bit
-        return keccak(for_hash).digest()
+        ecdata = ec.serialize(ecdata)[1:]  # Remove the first (type) bit
+
+        # TODO: Handle salt somehow
+        return HKDF(
+            algorithm=hashes.SHA256(),
+            length=32,
+            salt=None,
+            info=None,
+            backend=default_backend()
+        ).derive(ecdata)
 
     def gen_priv(self, dtype='ec'):
         # Same as in BBS98

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from distutils.core import setup, Extension
 
 # Haven't tried that on Windows or Mac
 
-INSTALL_REQUIRES = ['msgpack-python', 'pysha3']
+INSTALL_REQUIRES = ['msgpack-python', 'pysha3', 'cryptography']
 
 TESTS_REQUIRE = [
     'pytest',


### PR DESCRIPTION
### What this does:
1. Implements HKDF-SHA256 without a salt for Umbral's KDF.