### PR TITLE
Remove the use of bytesize and hardcode the length

### DIFF
--- a/npre/umbral.py
+++ b/npre/umbral.py
@@ -48,7 +48,7 @@ class PRE(object):
             else:
                 self.g = ec.deserialize(self.ecgroup, g)
 
-        self.bytesize = ec.bitsize(self.ecgroup)
+        self.bitsize = ec.bitsize(self.ecgroup)
 
     def kdf(self, ecdata):
         # XXX length
@@ -57,7 +57,7 @@ class PRE(object):
         # TODO: Handle salt somehow
         return HKDF(
             algorithm=hashes.SHA256(),
-            length=self.bytesize,
+            length=32,
             salt=None,
             info=None,
             backend=default_backend()


### PR DESCRIPTION
### What this does:
1. Bytesize/Bitsize is *not* the way to use variable length.